### PR TITLE
Hy duplicate get post api

### DIFF
--- a/routes/board.js
+++ b/routes/board.js
@@ -64,6 +64,7 @@ router.get('/:id', (req, res) => {
 
 // 게시물 생성 API
 // request: user_key, content, image1, image2, image3, image4, tag (json)
+// request로 받은 내용과 작성자 이름과 프로필 사진까지 함께 저장
 router.post('/', (req, res) => {
     const sql1 = `select name, portrait 
                 from profile 
@@ -74,7 +75,7 @@ router.post('/', (req, res) => {
 
         const sql2 = `insert into board (user_key, content, image1, image2, image3, image4, tag, writer_name, writer_portrait) 
                     values ($1, $2, $3, $4, $5, $6, $7, $8, $9);`;
-        const dbInput = [req.body.user_key, req.body.content, req.body.image1, req.body.image2, req.body.image3, req.body.image4, req.body.tag, rows.rows[0], rows.rows[1]];
+        const dbInput = [req.body.user_key, req.body.content, req.body.image1, req.body.image2, req.body.image3, req.body.image4, req.body.tag, rows.rows[0].name, rows.rows[0].portrait];
 
         pg.query(sql2, dbInput, (err) => {
             if (err) throw err;

--- a/routes/board.js
+++ b/routes/board.js
@@ -17,7 +17,7 @@ router.get('/', function(req,res) {
     // 가장 최근 게시물 10개를 받고 싶다면 cursor를 '999999999999999999999999'를 보내주면 됨.(9가 24개)
     // cursor가 클수록 최근 게시물
     // 직전에 받았던 게시물의 cursor보다 작은 cursor를 가지는 게시물들은 좀 더 오래된 게시물들
-    const sql = `select id, user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) as cursor
+    const sql = `select id, user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait, (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) as cursor
                 from board
                 where tag = ${tag} and (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) < ${cursor}
                 order by cursor desc
@@ -45,7 +45,7 @@ router.get('/:id', (req, res) => {
     const sql1 = `update board 
                 set view_count = view_count + 1 
                 where id = ${id};`; // 조회수 증가 쿼리
-    const sql2 = `select user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at 
+    const sql2 = `select user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait 
                 from board 
                 where id = ${id};`;
 

--- a/routes/board.js
+++ b/routes/board.js
@@ -17,7 +17,7 @@ router.get('/', function(req,res) {
     // 가장 최근 게시물 10개를 받고 싶다면 cursor를 '999999999999999999999999'를 보내주면 됨.(9가 24개)
     // cursor가 클수록 최근 게시물
     // 직전에 받았던 게시물의 cursor보다 작은 cursor를 가지는 게시물들은 좀 더 오래된 게시물들
-    const sql = `select id, user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait, (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) as cursor
+    const sql = `select id, user_key, writer_name, writer_portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) as cursor
                 from board
                 where tag = ${tag} and (to_char(created_at, 'YYYYMMDDHH24MISS') || lpad(id::text, 10, '0')) < ${cursor}
                 order by cursor desc
@@ -45,7 +45,7 @@ router.get('/:id', (req, res) => {
     const sql1 = `update board 
                 set view_count = view_count + 1 
                 where id = ${id};`; // 조회수 증가 쿼리
-    const sql2 = `select user_key, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait 
+    const sql2 = `select user_key, writer_name, writer_portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at 
                 from board 
                 where id = ${id};`;
 

--- a/routes/board.js
+++ b/routes/board.js
@@ -65,13 +65,21 @@ router.get('/:id', (req, res) => {
 // 게시물 생성 API
 // request: user_key, content, image1, image2, image3, image4, tag (json)
 router.post('/', (req, res) => {
-    const sql = `insert into board (user_key, content, image1, image2, image3, image4, tag) 
-                values ($1, $2, $3, $4, $5, $6, $7);`;
-    const dbInput = [req.body.user_key, req.body.content, req.body.image1, req.body.image2, req.body.image3, req.body.image4, req.body.tag];
+    const sql1 = `select name, portrait 
+                from profile 
+                where id = ${req.body.user_key};`
 
-    pg.query(sql, dbInput, (err) => {
+    pg.query(sql1, (err, rows) => {
         if (err) throw err;
-        res.sendStatus(201);
+
+        const sql2 = `insert into board (user_key, content, image1, image2, image3, image4, tag, writer_name, writer_portrait) 
+                    values ($1, $2, $3, $4, $5, $6, $7, $8, $9);`;
+        const dbInput = [req.body.user_key, req.body.content, req.body.image1, req.body.image2, req.body.image3, req.body.image4, req.body.tag, rows.rows[0], rows.rows[1]];
+
+        pg.query(sql2, dbInput, (err) => {
+            if (err) throw err;
+            res.sendStatus(201);
+        });
     });
 });
 

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -3,10 +3,10 @@ const router = express.Router();
 const pg = require('../db/index');
 
 // 사용자 정보 조회 API
-// request: id (query string) --> 없는 사용자일 경우 404 에러보다는 로그인/회원가입 창 뜨는 게 나을 것 같아서? 논의 필요
-router.get('/', (req, res) => {
+// request: id (parameter values) --> 없는 사용자일 경우 404 에러뜨기
+router.get('/:id', (req, res) => {
     var responseData = {};
-    const id = req.query.id;
+    const id = req.params.id;
 
     const sql = `select name, portrait, total_point, month_point
                 from profile
@@ -32,9 +32,9 @@ router.get('/mypost', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select board.id, name, portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
-                from profile, board
-                where profile.id = ${id} and board.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
+    const sql = `select id, name, portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
+                from board
+                where board.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
                 order by cursor desc
                 limit 10;`;
     
@@ -58,12 +58,10 @@ router.get('/mycomment', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select distinct b.id, p.name, p.portrait, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) as cursor
+    const sql = `select distinct b.id, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, b.writer_name, b.writer_portrait, (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) as cursor
                 from comment as c
                 inner join board as b
                 on b.id = c.board_key
-                inner join profile as p
-                on p.id = b.user_key
                 where c.user_key = ${id} and (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) < ${cursor}
                 order by cursor desc
                 limit 10;`;
@@ -88,13 +86,11 @@ router.get('/mycheer', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select board.id, name, portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
-                from cheer
-                inner join board
-                on board.id = cheer.board_key
-                inner join profile
-                on profile.id = board.user_key
-                where cheer.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
+    const sql = `select b.id, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, b.writer_name, b.writer_portrait, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
+                from cheer as c
+                inner join board as b
+                on b.id = c.board_key
+                where c.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
                 order by cursor desc
                 limit 10;`;
     

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -86,11 +86,11 @@ router.get('/mycheer', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select b.id, b.writer_name, b.writer_portrait, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
+    const sql = `select b.id, b.writer_name, b.writer_portrait, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) as cursor
                 from cheer as c
                 inner join board as b
                 on b.id = c.board_key
-                where c.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
+                where c.user_key = ${id} and (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) < ${cursor}
                 order by cursor desc
                 limit 10;`;
     

--- a/routes/mypage.js
+++ b/routes/mypage.js
@@ -4,7 +4,7 @@ const pg = require('../db/index');
 
 // 사용자 정보 조회 API
 // request: id (parameter values) --> 없는 사용자일 경우 404 에러뜨기
-router.get('/:id', (req, res) => {
+router.get('/user/:id', (req, res) => {
     var responseData = {};
     const id = req.params.id;
 
@@ -32,7 +32,7 @@ router.get('/mypost', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select id, name, portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, writer_name, writer_portrait, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
+    const sql = `select id, writer_name, writer_portrait, content, image1, image2, image3, image4, view_count, cheer_count, updated_at, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
                 from board
                 where board.user_key = ${id} and (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) < ${cursor}
                 order by cursor desc
@@ -58,7 +58,7 @@ router.get('/mycomment', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select distinct b.id, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, b.writer_name, b.writer_portrait, (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) as cursor
+    const sql = `select distinct b.id, b.writer_name, b.writer_portrait, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, (to_char(b.created_at, 'YYYYMMDDHH24MISS') || lpad(b.id::text, 10, '0')) as cursor
                 from comment as c
                 inner join board as b
                 on b.id = c.board_key
@@ -86,7 +86,7 @@ router.get('/mycheer', (req, res) => {
     const id = req.query.id;
     const cursor = req.query.cursor;
 
-    const sql = `select b.id, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, b.writer_name, b.writer_portrait, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
+    const sql = `select b.id, b.writer_name, b.writer_portrait, b.content, b.image1, b.image2, b.image3, b.image4, b.view_count, b.cheer_count, b.updated_at, (to_char(board.created_at, 'YYYYMMDDHH24MISS') || lpad(board.id::text, 10, '0')) as cursor
                 from cheer as c
                 inner join board as b
                 on b.id = c.board_key


### PR DESCRIPTION
## 작업 내용
- 게시물 생성 시 board 테이블에 writer_name, writer_portrait 컬럼 값도 저장하도록 변경
- 게시물 조회 API에서 writer_name, writer_portrait 값도 보내주도록 변경
- mypage의 내가 쓴 게시물, 댓글 쓴 게시물, 좋아요 누른 게시물 조인 연산 하나 삭제
- mypage의 좋아요 누른 게시물 SQL query 오류 수정

## 참고사항

