### PR TITLE
Je reset month point

### DIFF
--- a/scheduler/reset_point.js
+++ b/scheduler/reset_point.js
@@ -1,14 +1,18 @@
 const pg = require('../db/index');
 
 function reset_month_point() {
+	// 모든 유저의 month_point 값 0으로 초기화
 	const sql = `update profile set month_point=0;`;
 	pg.query(sql, (err) => {
 		if (err) throw err;
 	})
 }
 
+// 오늘 날짜 가져옴
 var today = new Date();
+// 오늘 날짜에서 며칠인지 가져옴 (1~최대31)
 var date = today.getDate();
 
+// 1일일 때만 함수 실행
 if (date == 1)
 	reset_month_point();


### PR DESCRIPTION
## 작업 내용
- 헤로쿠 스케줄러 add-ons 추가
<img width="312" alt="스크린샷 2022-05-26 오후 4 48 15" src="https://user-images.githubusercontent.com/61774034/170443018-e7dbb63d-7e64-44ff-8649-96769aca664d.png">

- 헤로쿠 스케줄러에서는 매일 0시 0분에 스케줄러를 돌려서 확인함. `node scheduler/reset_point.js` 파일을 실행함.
<img width="375" alt="스크린샷 2022-05-26 오후 4 48 59" src="https://user-images.githubusercontent.com/61774034/170443136-bc9d2b0e-62c2-4f57-be78-e72f3058fdbd.png">

- reset_point.js에서는 모든 유저의 month_point를 0으로 초기화하는 함수가 있음. 그리고 날짜를 확인해서 1일이면 그 함수를 실행함.


## 참고사항
